### PR TITLE
Test possible fix for missing notification responses when app is backgrounded or not running

### DIFF
--- a/apps/mobile/components/Notifier.tsx
+++ b/apps/mobile/components/Notifier.tsx
@@ -9,6 +9,7 @@ import {
   getExpoPushTokenAsync,
   getPermissionsAsync,
   getNotificationChannelsAsync,
+  setNotificationChannelGroupAsync,
   removeNotificationSubscription,
   requestPermissionsAsync,
   setNotificationChannelAsync,
@@ -48,8 +49,21 @@ const Notifier = () => {
     );
 
     if (Platform.OS === 'android') {
-      getNotificationChannelsAsync().then((value) => setChannels(value ?? []));
+      setNotificationChannelAsync('Miscellaneous', {
+        name: 'Miscellaneous',
+        importance: AndroidImportance.HIGH,
+      })
+        .then((value) => {
+          console.log(`Set channel ${value.name}`);
+          getNotificationChannelsAsync().then((value) =>
+            setChannels(value ?? []),
+          );
+        })
+        .catch((error) => {
+          console.log(`Error in setting channel: ${error}`);
+        });
     }
+
     notificationListener.current = addNotificationReceivedListener(
       (notification) => {
         setNotification(notification);

--- a/apps/mobile/components/Notifier.tsx
+++ b/apps/mobile/components/Notifier.tsx
@@ -9,11 +9,11 @@ import {
   getExpoPushTokenAsync,
   getPermissionsAsync,
   getNotificationChannelsAsync,
-  setNotificationChannelGroupAsync,
   removeNotificationSubscription,
   requestPermissionsAsync,
   setNotificationChannelAsync,
   setNotificationHandler,
+  useLastNotificationResponse,
 } from 'expo-notifications';
 import Constants from 'expo-constants';
 import { isDevice } from 'expo-device';
@@ -42,6 +42,8 @@ const Notifier = () => {
 
   const notificationListener = useRef<Subscription>();
   const responseListener = useRef<Subscription>();
+
+  const lastResponse = useLastNotificationResponse();
 
   useEffect(() => {
     registerForPushNotificationsAsync().then(
@@ -113,6 +115,10 @@ const Notifier = () => {
         <Text>
           Response received for:{' '}
           {response && response.notification.request.content.title}
+        </Text>
+        <Text>
+          Last response:{' '}
+          {lastResponse && lastResponse.notification.request.content.title}
         </Text>
       </View>
     </View>

--- a/patches/expo-notifications+0.28.1.patch
+++ b/patches/expo-notifications+0.28.1.patch
@@ -240,10 +240,10 @@ index 7b1add7..e22ec26 100644
     * See {@link FirebaseMessagingService#onDeletedMessages()}
 diff --git a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoNotificationLifecycleListener.java b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoNotificationLifecycleListener.java
 new file mode 100644
-index 0000000..55e3ab9
+index 0000000..3ae6481
 --- /dev/null
 +++ b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoNotificationLifecycleListener.java
-@@ -0,0 +1,79 @@
+@@ -0,0 +1,76 @@
 +package expo.modules.notifications.service.delegates;
 +
 +import android.app.Activity;
@@ -264,11 +264,9 @@ index 0000000..55e3ab9
 +
 +public class ExpoNotificationLifecycleListener implements ReactActivityLifecycleListener {
 +
-+    private Context mContext;
 +    private NotificationManager mNotificationManager;
 +
 +    public ExpoNotificationLifecycleListener(Context context, NotificationManager notificationManager) {
-+      mContext = context;
 +      mNotificationManager = notificationManager;
 +    }
 +
@@ -292,7 +290,6 @@ index 0000000..55e3ab9
 +                mNotificationManager.onNotificationResponseFromExtras(extras);
 +            }
 +        }
-+        ReactActivityLifecycleListener.super.onCreate(activity, savedInstanceState);
 +    }
 +
 +    /**

--- a/patches/expo-notifications+0.28.1.patch
+++ b/patches/expo-notifications+0.28.1.patch
@@ -1,0 +1,325 @@
+diff --git a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/NotificationsPackage.java b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/NotificationsPackage.java
+index a856e34..8005060 100644
+--- a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/NotificationsPackage.java
++++ b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/NotificationsPackage.java
+@@ -3,22 +3,32 @@ package expo.modules.notifications;
+ import android.content.Context;
+ 
+ import java.util.Arrays;
++import java.util.Collections;
+ import java.util.List;
+ 
+ import expo.modules.core.BasePackage;
+ import expo.modules.core.interfaces.InternalModule;
++import expo.modules.core.interfaces.ReactActivityLifecycleListener;
+ import expo.modules.core.interfaces.SingletonModule;
+ import expo.modules.notifications.notifications.NotificationManager;
+ import expo.modules.notifications.notifications.categories.serializers.ExpoNotificationsCategoriesSerializer;
+ import expo.modules.notifications.notifications.channels.AndroidXNotificationsChannelsProvider;
++import expo.modules.notifications.service.delegates.ExpoNotificationLifecycleListener;
+ import expo.modules.notifications.tokens.PushTokenManager;
+ 
+ public class NotificationsPackage extends BasePackage {
++
++  private NotificationManager mNotificationManager;
++
++  public NotificationsPackage() {
++    mNotificationManager = new NotificationManager();
++  }
++
+   @Override
+   public List<SingletonModule> createSingletonModules(Context context) {
+     return Arrays.asList(
+       new PushTokenManager(),
+-      new NotificationManager()
++      mNotificationManager
+     );
+   }
+ 
+@@ -29,4 +39,10 @@ public class NotificationsPackage extends BasePackage {
+       new ExpoNotificationsCategoriesSerializer()
+     );
+   }
++
++  @Override
++  public List<ReactActivityLifecycleListener> createReactActivityLifecycleListeners(Context activityContext) {
++    return Collections.singletonList(new ExpoNotificationLifecycleListener(activityContext, mNotificationManager));
++  }
+ }
++
+diff --git a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationManager.java b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationManager.java
+index 88da825..384a78b 100644
+--- a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationManager.java
++++ b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationManager.java
+@@ -1,5 +1,8 @@
+ package expo.modules.notifications.notifications;
+ 
++import android.os.Bundle;
++import android.util.Log;
++
+ import expo.modules.core.interfaces.SingletonModule;
+ 
+ import java.lang.ref.WeakReference;
+@@ -22,6 +25,7 @@ public class NotificationManager implements SingletonModule, expo.modules.notifi
+    */
+   private WeakHashMap<NotificationListener, WeakReference<NotificationListener>> mListenerReferenceMap;
+   private Collection<NotificationResponse> mPendingNotificationResponses = new ArrayList<>();
++  private Collection<Bundle> mPendingNotificationResponsesFromExtras = new ArrayList<>();
+ 
+   public NotificationManager() {
+     mListenerReferenceMap = new WeakHashMap<>();
+@@ -53,6 +57,11 @@ public class NotificationManager implements SingletonModule, expo.modules.notifi
+           listener.onNotificationResponseReceived(pendingResponse);
+         }
+       }
++      if (!mPendingNotificationResponsesFromExtras.isEmpty()) {
++        for (Bundle extras : mPendingNotificationResponsesFromExtras) {
++          listener.onNotificationResponseIntentReceived(extras);
++        }
++      }
+     }
+   }
+ 
+@@ -116,4 +125,17 @@ public class NotificationManager implements SingletonModule, expo.modules.notifi
+       }
+     }
+   }
++
++  public void onNotificationResponseFromExtras(Bundle extras) {
++    if (mPendingNotificationResponsesFromExtras.isEmpty()) {
++      mPendingNotificationResponsesFromExtras.add(extras);
++    } else {
++      for (WeakReference<NotificationListener> listenerReference : mListenerReferenceMap.values()) {
++        NotificationListener listener = listenerReference.get();
++        if (listener != null) {
++          listener.onNotificationResponseIntentReceived(extras);
++        }
++      }
++    }
++  }
+ }
+diff --git a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
+index fd04a2e..c65fabe 100644
+--- a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
++++ b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
+@@ -3,9 +3,9 @@ package expo.modules.notifications.notifications;
+ import android.os.Build;
+ import android.os.Bundle;
+ 
+-import androidx.annotation.NonNull;
+ import androidx.annotation.Nullable;
+ 
++import org.jetbrains.annotations.NotNull;
+ import org.json.JSONArray;
+ import org.json.JSONObject;
+ import expo.modules.core.arguments.MapArguments;
+@@ -19,16 +19,12 @@ import java.util.Set;
+ 
+ import expo.modules.notifications.notifications.interfaces.NotificationTrigger;
+ import expo.modules.notifications.notifications.model.Notification;
+-import expo.modules.notifications.notifications.model.NotificationAction;
+-import expo.modules.notifications.notifications.model.NotificationCategory;
+ import expo.modules.notifications.notifications.model.NotificationContent;
+ import expo.modules.notifications.notifications.model.NotificationRequest;
+ import expo.modules.notifications.notifications.model.NotificationResponse;
+-import expo.modules.notifications.notifications.model.TextInputNotificationAction;
+ import expo.modules.notifications.notifications.model.TextInputNotificationResponse;
+ import expo.modules.notifications.notifications.model.triggers.FirebaseNotificationTrigger;
+ 
+-import expo.modules.notifications.notifications.triggers.ChannelAwareTrigger;
+ import expo.modules.notifications.notifications.triggers.DailyTrigger;
+ import expo.modules.notifications.notifications.triggers.DateTrigger;
+ import expo.modules.notifications.notifications.triggers.TimeIntervalTrigger;
+@@ -199,4 +195,30 @@ public class NotificationSerializer {
+     }
+     return null;
+   }
++
++    @NotNull
++    public static Bundle toResponseBundleFromExtras(Bundle extras) {
++      Bundle serializedContent = new Bundle();
++      serializedContent.putString("title", extras.getString("title"));
++      serializedContent.putString("body", extras.getString("body"));
++
++      Bundle serializedTrigger = new Bundle();
++      serializedTrigger.putString("type", "push");
++      serializedTrigger.putString("channelId", extras.getString("channelId"));
++
++      Bundle serializedRequest = new Bundle();
++      serializedRequest.putString("identifier", extras.getString("google.message_id"));
++      serializedRequest.putBundle("trigger", serializedTrigger);
++      serializedRequest.putBundle("content", serializedContent);
++
++      Bundle serializedNotification = new Bundle();
++      serializedNotification.putLong("date", extras.getLong("google.sent_time"));
++      serializedNotification.putBundle("request", serializedRequest);
++
++      Bundle serializedResponse = new Bundle();
++      serializedResponse.putString("actionIdentifier", "expo.modules.notifications.actions.DEFAULT");
++      serializedResponse.putBundle("notification", serializedNotification);
++
++      return serializedResponse;
++    }
+ }
+diff --git a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.kt b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.kt
+index 8779a8a..e350c9a 100644
+--- a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.kt
++++ b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/emitting/NotificationsEmitter.kt
+@@ -1,6 +1,7 @@
+ package expo.modules.notifications.notifications.emitting
+ 
+ import android.os.Bundle
++import android.util.Log
+ import expo.modules.core.interfaces.services.EventEmitter
+ import expo.modules.kotlin.modules.Module
+ import expo.modules.kotlin.modules.ModuleDefinition
+@@ -16,8 +17,7 @@ private const val MESSAGES_DELETED_EVENT_NAME = "onNotificationsDeleted"
+ 
+ open class NotificationsEmitter : Module(), NotificationListener {
+   private lateinit var notificationManager: NotificationManager
+-  private var lastNotificationResponse: NotificationResponse? = null
+-  private var eventEmitter: EventEmitter? = null
++  private var lastNotificationResponseBundle: Bundle? = null
+ 
+   override fun definition() = ModuleDefinition {
+     Name("ExpoNotificationsEmitter")
+@@ -40,7 +40,7 @@ open class NotificationsEmitter : Module(), NotificationListener {
+     }
+ 
+     AsyncFunction<Bundle?>("getLastNotificationResponseAsync") {
+-      lastNotificationResponse?.let(NotificationSerializer::toBundle)
++      lastNotificationResponseBundle
+     }
+   }
+ 
+@@ -62,11 +62,16 @@ open class NotificationsEmitter : Module(), NotificationListener {
+    * @return Whether notification has been handled
+    */
+   override fun onNotificationResponseReceived(response: NotificationResponse): Boolean {
+-    lastNotificationResponse = response
+-    sendEvent(NEW_RESPONSE_EVENT_NAME, NotificationSerializer.toBundle(response))
++    lastNotificationResponseBundle = NotificationSerializer.toBundle(response)
++    sendEvent(NEW_RESPONSE_EVENT_NAME, lastNotificationResponseBundle)
+     return true
+   }
+ 
++  override fun onNotificationResponseIntentReceived(extras: Bundle?) {
++    lastNotificationResponseBundle = NotificationSerializer.toResponseBundleFromExtras(extras)
++    sendEvent(NEW_RESPONSE_EVENT_NAME, lastNotificationResponseBundle)
++  }
++
+   /**
+    * Callback called when [NotificationManager] gets informed of the fact of message dropping.
+    * Emits a [MESSAGES_DELETED_EVENT_NAME] event.
+diff --git a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationListener.java b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationListener.java
+index 7b1add7..e22ec26 100644
+--- a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationListener.java
++++ b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/interfaces/NotificationListener.java
+@@ -1,5 +1,7 @@
+ package expo.modules.notifications.notifications.interfaces;
+ 
++import android.os.Bundle;
++
+ import com.google.firebase.messaging.FirebaseMessagingService;
+ 
+ import expo.modules.notifications.notifications.model.Notification;
+@@ -28,6 +30,14 @@ public interface NotificationListener {
+     return false;
+   }
+ 
++  /**
++   * Callback called when notification response is received through package lifecycle listeners
++   *
++   * @param extras Bundle of extras from the lifecycle method
++   */
++  default void onNotificationResponseIntentReceived(Bundle extras) {
++  }
++
+   /**
+    * Callback called when some notifications are dropped.
+    * See {@link FirebaseMessagingService#onDeletedMessages()}
+diff --git a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoNotificationLifecycleListener.java b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoNotificationLifecycleListener.java
+new file mode 100644
+index 0000000..55e3ab9
+--- /dev/null
++++ b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoNotificationLifecycleListener.java
+@@ -0,0 +1,79 @@
++package expo.modules.notifications.service.delegates;
++
++import android.app.Activity;
++import android.app.NotificationChannel;
++import android.app.PendingIntent;
++import android.content.Context;
++import android.content.Intent;
++import android.os.Bundle;
++import android.os.Parcel;
++import android.util.Log;
++
++import androidx.core.app.NotificationCompat;
++
++import expo.modules.core.interfaces.ReactActivityLifecycleListener;
++import expo.modules.notifications.notifications.NotificationManager;
++import expo.modules.notifications.notifications.model.Notification;
++import expo.modules.notifications.notifications.model.NotificationResponse;
++
++public class ExpoNotificationLifecycleListener implements ReactActivityLifecycleListener {
++
++    private Context mContext;
++    private NotificationManager mNotificationManager;
++
++    public ExpoNotificationLifecycleListener(Context context, NotificationManager notificationManager) {
++      mContext = context;
++      mNotificationManager = notificationManager;
++    }
++
++    /**
++     * This will be triggered if the app is not running,
++     * and is started from clicking on a notification.
++     * <p>
++     * Notification data will be in activity.intent.extras
++     *
++     * @param activity
++     * @param savedInstanceState
++     */
++    @Override
++    public void onCreate(Activity activity, Bundle savedInstanceState) {
++        Intent intent = activity.getIntent();
++        String actionIdentifier = intent.getAction();
++        if (intent != null) {
++            Bundle extras = intent.getExtras();
++            if (extras != null) {
++                logExtra("onCreate", extras);
++                mNotificationManager.onNotificationResponseFromExtras(extras);
++            }
++        }
++        ReactActivityLifecycleListener.super.onCreate(activity, savedInstanceState);
++    }
++
++    /**
++     * This will be triggered if the app is running and in the background,
++     * and the user clicks on a notification to open the app.
++     * <p>
++     * Notification data will be in intent.extras
++     *
++     * @param intent
++     * @return
++     */
++    @Override
++    public boolean onNewIntent(Intent intent) {
++        Bundle extras = intent.getExtras();
++        String actionIdentifier = intent.getAction();
++        if (extras != null) {
++            logExtra("onNewIntent", extras);
++            mNotificationManager.onNotificationResponseFromExtras(extras);
++        }
++        return ReactActivityLifecycleListener.super.onNewIntent(intent);
++    }
++
++    private void logExtra(String method, Bundle extra) {
++        Log.d("ExpoNotificationLifecycleListener", method + " : keys count = " + extra.keySet().size());
++
++        for (String key : extra.keySet()) {
++            Log.d("ExpoNotificationLifecycleListener", method + " : key = " + key + " = " + extra.get(key).toString());
++        }
++    }
++}


### PR DESCRIPTION
- Experimental patch for `expo-notifications` package that uses Expo module API Android lifecycle listener methods
- Additions to the `Notifier` component to set the channel and to display the result of the `useLastNotificationResponse()` hook

When a user taps on a notification shown in the system UI, it opens the app, calling one of the lifecycle listener methods. A new serializer method takes the "extras" bundle passed into the lifecycle listener methods (`onCreate()`, `onNewIntent()`), and translates them into the bundle shape expected by the notification response JS events.

The patch works, but needs quite a bit of testing added to ensure that the new `NotificationSerializer` method is complete, and produces a bundle with the correct shape and all properties filled in correctly.

@christopherwalter FYI

